### PR TITLE
Quell warnings, improve portability

### DIFF
--- a/AdvectionDiffusion.C
+++ b/AdvectionDiffusion.C
@@ -283,6 +283,7 @@ static inline double L2Norm (double val)
   return val*val;
 }
 
+
 /*!
   \brief Returns the H1 semi-norm contribution in an integration point.
 */
@@ -292,9 +293,11 @@ static inline double H1Norm (const Vec3& grad)
   return grad*grad;
 }
 
-/* Unused function, consider remove
-// \brief Returns the residual in an integration point.
 
+/*!
+  \brief Returns the residual in an integration point.
+*/
+/*
 static inline double residualNorm (double val, const Vec3& U,
                                    const Vec3& grad, const Vec3& hess,
                                    double kappa, double f, double react)
@@ -303,6 +306,7 @@ static inline double residualNorm (double val, const Vec3& U,
   return res*res;
 }
 */
+
 
 bool AdvectionDiffusionNorm::evalInt (LocalIntegral& elmInt,
                                       const FiniteElement& fe,

--- a/AdvectionDiffusion.h
+++ b/AdvectionDiffusion.h
@@ -51,16 +51,19 @@ public:
     //! \brief Defines which FE quantities are needed by the integrand.
     virtual int getIntegrandType() const { return ELEMENT_CORNERS; }
 
+    using IntegrandBase::getLocalIntegral;
     //! \brief Returns a local integral contribution object for given element.
     //! \param[in] nen Number of nodes on element
     virtual LocalIntegral* getLocalIntegral(size_t nen, size_t, bool) const;
 
+    using IntegrandBase::initElementBou;
     //! \brief Initializes current element for boundary integration.
     //! \param[in] MNPC Matrix of nodal point correspondance for current element
     //! \param elmInt Local integral for element
     virtual bool initElementBou(const std::vector<int>& MNPC,
                                 LocalIntegral& elmInt);
 
+    using IntegrandBase::evalBou;
     //! \brief Evaluates the integrand at a boundary point.
     //! \param elmInt The local integral object to receive the contributions
     //! \param[in] fe Finite element data of current integration point
@@ -154,6 +157,7 @@ public:
   //! \brief Defines which FE quantities are needed by the integrand.
   virtual int getIntegrandType() const;
 
+  using IntegrandBase::getLocalIntegral;
   //! \brief Returns a local integral container for the given element.
   //! \param[in] nen Number of nodes on element
   //! \param[in] neumann Whether or not we are assembling Neumann BC's
@@ -167,6 +171,7 @@ public:
   //! element quantities are assembled into their system level equivalents.
   virtual bool finalizeElement(LocalIntegral& elmInt);
 
+  using IntegrandBase::evalInt;
   //! \brief Evaluates the integrand at an interior point.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Finite element data of current integration point
@@ -174,6 +179,7 @@ public:
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X) const;
 
+  using IntegrandBase::evalBou;
   //! \brief Evaluates the integrand at a boundary point.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Finite element data of current integration point
@@ -182,6 +188,7 @@ public:
   virtual bool evalBou(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X, const Vec3& normal) const;
 
+  using IntegrandBase::evalSol;
   //! \brief Evaluates the secondary solution at a result point.
   //! \param[out] s Array of solution field values at current point
   //! \param[in] fe Finite element data at current point
@@ -249,6 +256,7 @@ public:
   //! \brief Empty destructor.
   virtual ~AdvectionDiffusionNorm() {}
 
+  using NormBase::evalInt;
   //! \brief Evaluates the integrand at an interior point.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Finite element data of current integration point
@@ -292,6 +300,7 @@ public:
   //! \brief Empty destructor.
   virtual ~ADNorm() {}
 
+  using NormBase::evalInt;
   //! \brief Evaluates the integrand at an interior point.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Finite element data of current integration point

--- a/AdvectionDiffusionExplicit.h
+++ b/AdvectionDiffusionExplicit.h
@@ -51,6 +51,7 @@ public:
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X) const;
 
+  using AdvectionDiffusion::getLocalIntegral;
   //! \brief Returns a local integral container for the given element.
   //! \param[in] nen Number of nodes on element
   //! \param[in] neumann Whether or not we are assembling Neumann BC's

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,6 @@ include_directories(${IFEM_INCLUDES} ../Common ${PROJECT_SOURCE_DIR})
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
-if(NOT WIN32)
-  # Emit position-independent code, suitable for dynamic linking
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-  # Enable all warnings
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-endif()
-
 add_library(CommonAD STATIC AdvectionDiffusion.C
                             AdvectionDiffusionArgs.C
                             AdvectionDiffusionBDF.C

--- a/SIMAD.h
+++ b/SIMAD.h
@@ -320,8 +320,9 @@ public:
     doSerializeOps(ar);
     data.insert(std::make_pair(this->getName(), str.str()));
     return true;
-#endif
+#else
     return false;
+#endif
   }
 
   //! \brief Set internal state from a serialized state.
@@ -336,8 +337,8 @@ public:
       cereal::BinaryInputArchive ar(str);
       doSerializeOps(ar);
       AD.advanceStep();
+      return true;
     }
-    return true;
 #endif
     return false;
   }


### PR DESCRIPTION
This quells warnings due to mix of virtual/overloads, and removes compiler flags now handled by ifem core.