### PR TITLE
Fix memory leaks and add modified element size support

### DIFF
--- a/Common/AdvectionDiffusion/AdvectionDiffusion.C
+++ b/Common/AdvectionDiffusion/AdvectionDiffusion.C
@@ -338,7 +338,14 @@ bool AdvectionDiffusionNorm::evalInt (LocalIntegral& elmInt,
           U = (*hep.Uad)(X);
         double react = hep.reaction ? (*hep.reaction)(X) : 0.0;
         double res = f + kappa*hess.sum() - U*gradUh - react*Uh;
-        double kk = fe.h;//fe.h*std::min(1.0/(sqrt(2.0)*sqrt(13.0)),fe.h/(3.0*sqrt(10.0)*hep.props.getDiffusivity()));
+        double kk;
+        if (hep.useModifiedElmSize()) {
+          if (hep.getCbar() > 0.0)
+            kk = std::min(fe.h/sqrt(kappa), 1.0/sqrt(hep.getCbar()));
+          else
+            kk = fe.h/sqrt(kappa);
+        } else
+          kk = fe.h;
         ip++; // unused
         pnorm[ip++] += kk*kk*res*res*fe.detJxW;
         if (anasol && anasol->getScalarSecSol())

--- a/Common/AdvectionDiffusion/AdvectionDiffusion.C
+++ b/Common/AdvectionDiffusion/AdvectionDiffusion.C
@@ -35,9 +35,7 @@ AdvectionDiffusion::AdvectionDiffusion (unsigned short int n,
   : IntegrandBase(n), order(1), stab(s), Cinv(5.0), residualNorm(false)
 {
   primsol.resize(1);
-
-  Uad = nullptr;
-  reaction = source = flux = nullptr;
+  flux = nullptr;
 
   velocity.resize(2);
   registerVector("velocity1", &velocity[0]);
@@ -47,9 +45,6 @@ AdvectionDiffusion::AdvectionDiffusion (unsigned short int n,
 
 AdvectionDiffusion::~AdvectionDiffusion()
 {
-  delete Uad;
-  delete reaction;
-  delete source;
 }
 
 

--- a/Common/AdvectionDiffusion/AdvectionDiffusion.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusion.h
@@ -18,6 +18,7 @@
 
 #include "ElmMats.h"
 #include "EqualOrderOperators.h"
+#include "Functions.h"
 #include "IntegrandBase.h"
 #include "MatVec.h"
 #include "SIMenums.h"
@@ -33,7 +34,6 @@ class AnaSol;
 class Fields;
 class FiniteElement;
 class LocalIntegral;
-class RealFunc;
 class Vec3;
 class VecFunc;
 
@@ -126,7 +126,7 @@ public:
   virtual ~AdvectionDiffusion();
 
   //! \brief Defines the source function.
-  void setSource(RealFunc* src) { source = src; }
+  void setSource(RealFunc* src) { source.reset(src); }
 
   //! \brief Defines the Cinv stabilization parameter.
   void setCinv(double Cinv_) { Cinv = Cinv_; }
@@ -152,13 +152,13 @@ public:
   Stabilization getStabilization() const { return stab; }
 
   //! \brief Defines the advection field.
-  void setAdvectionField(VecFunc* U) { Uad = U; }
+  void setAdvectionField(VecFunc* U) { Uad.reset(U); }
 
   //! \brief Defines the flux function.
   void setFlux(RealFunc* f) { flux = f; }
 
   //! \brief Defines the reaction field.
-  void setReactionField(RealFunc* f) { reaction = f; }
+  void setReactionField(RealFunc* f) { reaction.reset(f); }
 
   //! \brief Defines the global number of elements.
   void setElements(size_t els) { tauE.resize(els); }
@@ -270,9 +270,9 @@ public:
 
 
 protected:
-  VecFunc*  Uad;      //!< Pointer to advection field
-  RealFunc* reaction; //!< Pointer to the reaction field
-  RealFunc* source;   //!< Pointer to source field
+  std::unique_ptr<VecFunc>  Uad;      //!< Pointer to advection field
+  std::unique_ptr<RealFunc> reaction; //!< Pointer to the reaction field
+  std::unique_ptr<RealFunc> source;   //!< Pointer to source field
   RealFunc* flux;     //!< Pointer to the flux field
   double timeScale = 1.0; //!< Time scale factor
 

--- a/Common/AdvectionDiffusion/AdvectionDiffusion.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusion.h
@@ -133,6 +133,18 @@ public:
   //! \brief Returns the current Cinv value.
   double getCinv() const { return Cinv; }
 
+  //! \brief Defines the Cbar element size parameter.
+  void setCbar(double Cbar_) { Cbar = Cbar_; }
+
+  //! \brief Returns the current Cbar value.
+  double getCbar() const { return Cbar; }
+
+  //! \brief Defines whether or not to use modified element size in residual estimator.
+  void setModified(bool use) { useModified = use; }
+
+  //! \brief Returns whether or not to use modified element size in residual estimator.
+  bool useModifiedElmSize() const { return useModified; }
+
   //! \brief Defines the stabilization type.
   void setStabilization(Stabilization s) { stab = s; }
 
@@ -271,7 +283,9 @@ protected:
 
   Stabilization stab; //!< The type of stabilization used
   double        Cinv; //!< Stabilization parameter
+  double        Cbar = 0.0; //!< Used in element size calculations
   bool  residualNorm; //!< If \e true, we will evaluate residual norm
+  bool useModified = false; //!< If \e true use modified element size in residual estimate
   WeakOperators::ConvectionForm advForm = WeakOperators::CONVECTIVE; //!< Advection formulation to use
 
   Vectors velocity; //!< The advecting velocity field

--- a/Common/AdvectionDiffusion/SIMAD.C
+++ b/Common/AdvectionDiffusion/SIMAD.C
@@ -170,7 +170,19 @@ bool SIMAD<Dim,Integrand>::parse (const TiXmlElement* elem)
         AD.setAdvectionForm(WeakOperators::CONSERVATIVE);
       }
     }
-    else
+    else if (strcasecmp(child->Value(),"residual") == 0) {
+      bool useModified = false;
+      utl::getAttribute(child,"modified_elm_size",useModified);
+      if (useModified)
+        IFEM::cout << "\tUsing modified element size in residual estimator." << std::endl;
+      AD.setModified(useModified);
+      double Cbar = 0.0;
+      utl::getAttribute(child,"Cbar",Cbar);
+      if (Cbar > 0.0) {
+        AD.setCbar(Cbar);
+        IFEM::cout << "\tUpper bound for reaction field: " << Cbar << std::endl;
+      }
+    } else
       this->Dim::parse(child);
 
   return true;


### PR DESCRIPTION
- Use unique_ptr to ensure functions are cleaned up when a new function is assigned
- Support for modified element size in residual estimator