### PR TITLE
fixed: we need to take the square of the errors for the estimator

### DIFF
--- a/Common/AdvectionDiffusion/AdvectionDiffusion.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusion.h
@@ -174,10 +174,10 @@ public:
   //! \brief Defines which FE quantities are needed by the integrand.
   int getIntegrandType() const override;
 
-  //! \brief Set whether we evaluate residual norm
+  //! \brief Set whether we evaluate residual norm.
   void setResidualNorm(bool on) { residualNorm = on; }
 
-  //! \brief True if we evaluate residual norm
+  //! \brief True if we evaluate residual norm.
   bool doResidualNorm() const { return residualNorm; }
 
   using IntegrandBase::getLocalIntegral;

--- a/Common/AdvectionDiffusion/SIMAD.C
+++ b/Common/AdvectionDiffusion/SIMAD.C
@@ -403,6 +403,27 @@ SIM::ConvStatus SIMAD<Dim,Integrand>::solveIteration (TimeStep& tp)
 
 
 template<class Dim, class Integrand>
+bool SIMAD<Dim,Integrand>::postProcessNorms (Vectors& gNorm,
+                                             Matrix* eNormp)
+{
+  if (this->opt.project.empty() || !eNormp)
+    return true;
+
+  NormBase* norm = AD.getNormIntegrand(Dim::mySol);
+  size_t ip = norm->getNoFields(1);
+  delete norm;
+
+  Matrix& eNorm = *eNormp;
+  for (size_t i = 1; i <= eNorm.cols(); ++ i) {
+    // we need the squares for multi-patch summations
+    eNorm(ip+2,i) = eNorm(ip+2,i)*eNorm(ip+2,i);
+  }
+
+  return true;
+}
+
+
+template<class Dim, class Integrand>
 void SIMAD<Dim,Integrand>::printNorms (const Vectors& norms, size_t) const
 {
   if (norms.empty()) return;

--- a/Common/AdvectionDiffusion/SIMAD.h
+++ b/Common/AdvectionDiffusion/SIMAD.h
@@ -166,6 +166,9 @@ public:
   //! \param scale Time scaling factor
   void setTimeScale(double scale) { AD.setTimeScale(scale); }
 
+  //! \brief Apply post-processing tasks on norms.
+  bool postProcessNorms(Vectors& gNorm, Matrix* eNormp) override;
+
   //! \brief Prints integrated solution norms to the log stream.
   //! \param[in] norms The norm values
   void printNorms (const Vectors& norms, size_t) const override;

--- a/Test/Square-ad-adap-rec-noana.reg
+++ b/Test/Square-ad-adap-rec-noana.reg
@@ -6,15 +6,14 @@ Number of nodes       81
 Number of dofs        81
 Number of constraints 32
 Number of unknowns    49
+	Refinement percentage: 10 type=1
+	Refinement scheme: 2
 Enabled projection(s): Continuous global L2-projection
-
  >>> Starting adaptive simulation based on
      Continuous global L2-projection error estimates (norm group 1) <<<
 Adaptive step 1
 L2-norm            : 0.0703478
 Max temperature    : 0.333333
-Projecting secondary solution ...
-	Continuous global L2-projection
 >>> Norm summary for AdvectionDiffusion <<<
   L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0567639
   H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135588
@@ -22,54 +21,50 @@ Error estimates based on >>> Continuous global L2-projection <<<
   H1 norm |T^r-T^h|                  : 0.0109273
 Error estimate a(e,e)^0.5, e=T^r-T^h : 0.0109273
 Relative error (%) : 18.9033
-Root mean square (RMS) of error      : 0.947684
-Min element error                    : 3.08336e-06
-Max element error                    : 0.0042274
-Average element error                : 0.000991428
-Refining 50 basis functions with errors in range \[0.00148772,0.0133136\] 10% of max error (0.00133136)
-Refined mesh: 214 elements 238 nodes.
+Root mean square (RMS) of error      : 1.69368
+Min element error                    : 9.5071e-12
+Max element error                    : 1.78709e-05
+Average element error                : 1.8657e-06
+Refining 28 basis functions with errors in range \[4.82643e-06,4.56083e-05\] 10% of max error (4.56083e-06)
+Refined mesh: 157 elements 176 nodes.
 Adaptive step 2
-Number of elements    214
-Number of nodes       238
-Number of dofs        238
-Number of constraints 55
-Number of unknowns    183
-L2-norm            : 0.0698201
+Number of elements    157
+Number of nodes       176
+Number of dofs        176
+Number of constraints 48
+Number of unknowns    128
+L2-norm            : 0.0811242
 Max temperature    : 0.333333
-Projecting secondary solution ...
-	Continuous global L2-projection
 >>> Norm summary for AdvectionDiffusion <<<
   L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0564411
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135464
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135465
 Error estimates based on >>> Continuous global L2-projection <<<
-  H1 norm |T^r-T^h|                  : 0.00556922
-Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00556922
-Relative error (%) : 9.81962
-Root mean square (RMS) of error      : 0.783647
-Min element error                    : 3.13089e-06
-Max element error                    : 0.00123131
-Average element error                : 0.000299655
-Refining 185 basis functions with errors in range \[0.000423284,0.00415853\] 10% of max error (0.000415853)
-Refined mesh: 769 elements 802 nodes.
+  H1 norm |T^r-T^h|                  : 0.00587499
+Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00587499
+Relative error (%) : 10.3531
+Root mean square (RMS) of error      : 1.06609
+Min element error                    : 9.22907e-12
+Max element error                    : 1.51615e-06
+Average element error                : 2.19844e-07
+Refining 101 basis functions with errors in range \[4.50221e-07,4.39342e-06\] 10% of max error (4.39342e-07)
+Refined mesh: 490 elements 514 nodes.
 Adaptive step 3
-Number of elements    769
-Number of nodes       802
-Number of dofs        802
-Number of constraints 95
-Number of unknowns    707
-L2-norm            : 0.0697495
+Number of elements    490
+Number of nodes       514
+Number of dofs        514
+Number of constraints 82
+Number of unknowns    432
+L2-norm            : 0.086774
 Max temperature    : 0.333333
-Projecting secondary solution ...
-	Continuous global L2-projection
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563673
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135456
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.056368
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135455
 Error estimates based on >>> Continuous global L2-projection <<<
-  H1 norm |T^r-T^h|                  : 0.00282316
-Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00282316
-Relative error (%) : 5.00224
-Root mean square (RMS) of error      : 0.686885
-Min element error                    : 2.69367e-06
-Max element error                    : 0.000331733
-Average element error                : 8.39163e-05
+  H1 norm |T^r-T^h|                  : 0.00319508
+Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00319508
+Relative error (%) : 5.65917
+Root mean square (RMS) of error      : 0.833731
+Min element error                    : 9.062e-12
+Max element error                    : 1.10047e-07
+Average element error                : 2.08338e-08
    \* Stopping the adaptive cycles as max steps 3 was reached.

--- a/Test/Square-ad-adap-rec.hreg
+++ b/Test/Square-ad-adap-rec.hreg
@@ -40,72 +40,72 @@ Square-ad-adap-rec.xinp -adap
 /1                       Group
 /1/AdvectionDiffusion-1  Group
 /1/AdvectionDiffusion-1/basis Group
-/1/AdvectionDiffusion-1/basis/1 Dataset {29708}
+/1/AdvectionDiffusion-1/basis/1 Dataset {21564}
 /1/AdvectionDiffusion-1/fields Group
 /1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x Group
-/1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x/1 Dataset {238}
+/1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x/1 Dataset {176}
 /1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y Group
-/1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y/1 Dataset {238}
+/1/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y/1 Dataset {176}
 /1/AdvectionDiffusion-1/fields/T Group
-/1/AdvectionDiffusion-1/fields/T/1 Dataset {238}
+/1/AdvectionDiffusion-1/fields/T/1 Dataset {176}
 /1/AdvectionDiffusion-1/fields/T,x Group
-/1/AdvectionDiffusion-1/fields/T,x/1 Dataset {238}
+/1/AdvectionDiffusion-1/fields/T,x/1 Dataset {176}
 /1/AdvectionDiffusion-1/fields/T,y Group
-/1/AdvectionDiffusion-1/fields/T,y/1 Dataset {238}
+/1/AdvectionDiffusion-1/fields/T,y/1 Dataset {176}
 /1/AdvectionDiffusion-1/knotspan Group
 /1/AdvectionDiffusion-1/knotspan/(T,T)^0.5 Group
-/1/AdvectionDiffusion-1/knotspan/(T,T)^0.5/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/(T,T)^0.5/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5 Group
-/1/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h Group
-/1/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5 Group
-/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r Group
-/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h Group
-/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
-/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/a(T,T)^0.5 Group
-/1/AdvectionDiffusion-1/knotspan/a(T,T)^0.5/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/a(T,T)^0.5/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5 Group
-/1/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5/1 Dataset {157}
 /1/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h Group
-/1/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h/1 Dataset {214}
+/1/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h/1 Dataset {157}
 /2                       Group
 /2/AdvectionDiffusion-1  Group
 /2/AdvectionDiffusion-1/basis Group
-/2/AdvectionDiffusion-1/basis/1 Dataset {112930}
+/2/AdvectionDiffusion-1/basis/1 Dataset {71107}
 /2/AdvectionDiffusion-1/fields Group
 /2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x Group
-/2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x/1 Dataset {802}
+/2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,x/1 Dataset {514}
 /2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y Group
-/2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y/1 Dataset {802}
+/2/AdvectionDiffusion-1/fields/Continuous\ global\ L2-projection\ T,y/1 Dataset {514}
 /2/AdvectionDiffusion-1/fields/T Group
-/2/AdvectionDiffusion-1/fields/T/1 Dataset {802}
+/2/AdvectionDiffusion-1/fields/T/1 Dataset {514}
 /2/AdvectionDiffusion-1/fields/T,x Group
-/2/AdvectionDiffusion-1/fields/T,x/1 Dataset {802}
+/2/AdvectionDiffusion-1/fields/T,x/1 Dataset {514}
 /2/AdvectionDiffusion-1/fields/T,y Group
-/2/AdvectionDiffusion-1/fields/T,y/1 Dataset {802}
+/2/AdvectionDiffusion-1/fields/T,y/1 Dataset {514}
 /2/AdvectionDiffusion-1/knotspan Group
 /2/AdvectionDiffusion-1/knotspan/(T,T)^0.5 Group
-/2/AdvectionDiffusion-1/knotspan/(T,T)^0.5/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/(T,T)^0.5/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5 Group
-/2/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/(T^h,T^h)^0.5/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h Group
-/2/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/(e,e)^0.5,\ e=T-T^h/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5 Group
-/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(T^r,T^r)^0.5/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r Group
-/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T-T^r/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h Group
-/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=T^r-T^h/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
-/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/a(T,T)^0.5 Group
-/2/AdvectionDiffusion-1/knotspan/a(T,T)^0.5/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/a(T,T)^0.5/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5 Group
-/2/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/a(T^h,T^h)^0.5/1 Dataset {490}
 /2/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h Group
-/2/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h/1 Dataset {769}
+/2/AdvectionDiffusion-1/knotspan/a(e,e)^0.5,\ e=T-T^h/1 Dataset {490}

--- a/Test/Square-ad-adap-rec.reg
+++ b/Test/Square-ad-adap-rec.reg
@@ -10,6 +10,8 @@ Enabled projection(s): Continuous global L2-projection
  >>> Starting adaptive simulation based on
      Continuous global L2-projection error estimates (norm group 1) <<<
 Adaptive step 1
+L2-norm            : 0.0703478
+Max temperature    : 0.333333
 >>> Norm summary for AdvectionDiffusion <<<
   L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0567639
   H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135588
@@ -25,67 +27,66 @@ Error estimates based on >>> Continuous global L2-projection <<<
 Error estimate a(e,e)^0.5, e=T^r-T^h : 0.0109273
 Relative error (%) : 18.9033
 Effectivity index  : 0.956463
-Root mean square (RMS) of error      : 0.947684
-Min element error                    : 3.08336e-06
-Max element error                    : 0.0042274
-Average element error                : 0.000991428
-Refining 50 basis functions with errors in range \[0.00148772,0.0133136\] 10% of max error (0.00133136)
+Root mean square (RMS) of error      : 1.69368
+Min element error                    : 9.5071e-12
+Max element error                    : 1.78709e-05
+Average element error                : 1.8657e-06
+Refining 28 basis functions with errors in range \[4.82643e-06,4.56083e-05\] 10% of max error (4.56083e-06)
+Refined mesh: 157 elements 176 nodes.
 Adaptive step 2
-Number of elements    214
-Number of nodes       238
-Number of dofs        238
-Number of constraints 55
-Number of unknowns    183
-L2-norm            : 0.0698201
+Number of elements    157
+Number of nodes       176
+Number of dofs        176
+Number of constraints 48
+Number of unknowns    128
+L2-norm            : 0.0811242
 Max temperature    : 0.333333
-Projecting secondary solution ...
-	Continuous global L2-projection
 >>> Norm summary for AdvectionDiffusion <<<
   L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0564411
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135464
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135465
   L2 norm |T|   = (T,T)^0.5           : 0.0563436
   H1 norm |T|   = a(T,T)^0.5          : 0.135459
-  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 0.000138679
-  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00570192
-  Exact relative error (%)            : 4.20932
+  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 0.000177886
+  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00603363
+  Exact relative error (%)            : 4.4542
 Error estimates based on >>> Continuous global L2-projection <<<
-  H1 norm |T^r-T^h|                  : 0.00556922
-  H1 norm |T^r-T|                    : 0.00122728
-  Effectivity index eta^T            : 0.976727
-Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00556922
-Relative error (%) : 9.81962
-Effectivity index  : 0.976727
-Root mean square (RMS) of error      : 0.783647
-Min element error                    : 3.13089e-06
-Max element error                    : 0.00123131
-Average element error                : 0.000299655
-Refining 185 basis functions with errors in range \[0.000423284,0.00415853\] 10% of max error (0.000415853)
+  H1 norm |T^r-T^h|                  : 0.00587499
+  H1 norm |T^r-T|                    : 0.00142047
+  Effectivity index eta^T            : 0.973707
+Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00587499
+Relative error (%) : 10.3531
+Effectivity index  : 0.973707
+Root mean square (RMS) of error      : 1.06609
+Min element error                    : 9.22907e-12
+Max element error                    : 1.51615e-06
+Average element error                : 2.19844e-07
+Refining 101 basis functions with errors in range \[4.50221e-07,4.39342e-06\] 10% of max error (4.39342e-07)
+Refined mesh: 490 elements 514 nodes.
 Adaptive step 3
-Number of elements    769
-Number of nodes       802
-Number of dofs        802
-Number of constraints 95
-Number of unknowns    707
-L2-norm            : 0.0697495
+Number of elements    490
+Number of nodes       514
+Number of dofs        514
+Number of constraints 82
+Number of unknowns    432
+L2-norm            : 0.086774
 Max temperature    : 0.333333
-Projecting secondary solution ...
-	Continuous global L2-projection
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563673
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135456
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.056368
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.135455
   L2 norm |T|   = (T,T)^0.5           : 0.0563436
   H1 norm |T|   = a(T,T)^0.5          : 0.135459
-  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 3.5641e-05
-  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00285984
-  Exact relative error (%)            : 2.11122
+  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 6.03245e-05
+  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00326182
+  Exact relative error (%)            : 2.40797
 Error estimates based on >>> Continuous global L2-projection <<<
-  H1 norm |T^r-T^h|                  : 0.00282316
-  H1 norm |T^r-T|                    : 0.000460157
-  Effectivity index eta^T            : 0.987173
-Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00282316
-Relative error (%) : 5.00224
-Effectivity index  : 0.987173
-Root mean square (RMS) of error      : 0.686885
-Min element error                    : 2.69367e-06
-Max element error                    : 0.000331733
-Average element error                : 8.39163e-05
+  H1 norm |T^r-T^h|                  : 0.00319508
+  H1 norm |T^r-T|                    : 0.000671701
+  Effectivity index eta^T            : 0.97954
+Error estimate a(e,e)^0.5, e=T^r-T^h : 0.00319508
+Relative error (%) : 5.65917
+Effectivity index  : 0.97954
+Root mean square (RMS) of error      : 0.833731
+Min element error                    : 9.062e-12
+Max element error                    : 1.10047e-07
+Average element error                : 2.08338e-08
+   \* Stopping the adaptive cycles as max steps 3 was reached.

--- a/Test/Square-ad-adap-rec.vreg
+++ b/Test/Square-ad-adap-rec.vreg
@@ -26,8 +26,8 @@ Step 1
     Scalar: 'Continuous global L2-projection effectivity index'
 Step 2
   Element block 1
-    856 nodes
-    214 elements
+    628 nodes
+    157 elements
     Displacement: 'Solution'
     Displacement: 'Exact Solution'
     Scalar: 'T'
@@ -50,8 +50,8 @@ Step 2
     Scalar: 'Continuous global L2-projection effectivity index'
 Step 3
   Element block 1
-    3076 nodes
-    769 elements
+    1960 nodes
+    490 elements
     Displacement: 'Solution'
     Displacement: 'Exact Solution'
     Scalar: 'T'

--- a/Test/Square-ad-adap-res-noana.reg
+++ b/Test/Square-ad-adap-res-noana.reg
@@ -6,6 +6,8 @@ Number of nodes       81
 Number of dofs        81
 Number of constraints 32
 Number of unknowns    49
+	Refinement percentage: 10 type=1
+	Refinement scheme: 2
 Pure residual error estimates enabled
  >>> Starting adaptive simulation based on
      Pure residuals error estimates (norm group 1) <<<
@@ -19,51 +21,50 @@ Error estimates based on >>> Pure residuals <<<
   Residual norm                      : 0.125968
 Error estimate             |T^h|_res : 0.125968
 Relative error (%) : 91.1701
-Root mean square (RMS) of error      : 0.997473
-Min element error                    : 3.07588e-05
-Max element error                    : 0.0488364
-Average element error                : 0.0111482
-
-Refining 49 basis functions with errors in range \[0.0175035,0.160098\] 10% of max error (0.0160098)
-Refined mesh: 211 elements 234 nodes.
+Root mean square (RMS) of error      : 1.78483
+Min element error                    : 9.46105e-10
+Max element error                    : 0.00238499
+Average element error                : 0.000247937
+Refining 26 basis functions with errors in range \[0.000680429,0.0065528\] 10% of max error (0.00065528)
+Refined mesh: 148 elements 165 nodes.
 Adaptive step 2
-Number of elements    211
-Number of nodes       234
-Number of dofs        234
-Number of constraints 54
-Number of unknowns    180
-L2-norm            : 0.0704152
+Number of elements    148
+Number of nodes       165
+Number of dofs        165
+Number of constraints 45
+Number of unknowns    120
+L2-norm            : 0.0837822
 Max temperature    : 0.333333
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.056442
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.24732
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0564416
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.247316
 Error estimates based on >>> Pure residuals <<<
-  Residual norm                      : 0.0631065
-Error estimate             |T^h|_res : 0.0631065
-Relative error (%) : 74.5369
-Root mean square (RMS) of error      : 0.818224
-Min element error                    : 3.07588e-05
-Max element error                    : 0.0134167
-Average element error                : 0.00336233
-Refining 181 basis functions with errors in range \[0.00487477,0.0487098\] 10% of max error (0.00487098)
-Refined mesh: 754 elements 788 nodes.
+  Residual norm                      : 0.0674546
+Error estimate             |T^h|_res : 0.0674546
+Relative error (%) : 76.6937
+Root mean square (RMS) of error      : 1.11494
+Min element error                    : 9.46105e-10
+Max element error                    : 0.000180008
+Average element error                : 3.07441e-05
+Refining 98 basis functions with errors in range \[6.0148e-05,0.000596129\] 10% of max error (5.96129e-05)
+Refined mesh: 448 elements 471 nodes.
 Adaptive step 3
-Number of elements    754
-Number of nodes       788
-Number of dofs        788
-Number of constraints 96
-Number of unknowns    692
-L2-norm            : 0.0703668
+Number of elements    448
+Number of nodes       471
+Number of dofs        471
+Number of constraints 77
+Number of unknowns    394
+L2-norm            : 0.0906022
 Max temperature    : 0.333333
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563674
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.247307
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563679
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.24731
 Error estimates based on >>> Pure residuals <<<
-  Residual norm                      : 0.0317011
-Error estimate             |T^h|_res : 0.0317011
-Relative error (%) : 49.0196
-Root mean square (RMS) of error      : 0.715177
-Min element error                    : 3.07588e-05
-Max element error                    : 0.00351516
-Average element error                : 0.000939048
+  Residual norm                      : 0.0366483
+Error estimate             |T^h|_res : 0.0366483
+Relative error (%) : 54.5084
+Root mean square (RMS) of error      : 0.882191
+Min element error                    : 9.46105e-10
+Max element error                    : 1.50024e-05
+Average element error                : 2.99799e-06
    \* Stopping the adaptive cycles as max steps 3 was reached.

--- a/Test/Square-ad-adap-res.reg
+++ b/Test/Square-ad-adap-res.reg
@@ -1,8 +1,5 @@
 Square-ad-adap-res.xinp -adap
 
-Input file: Square-ad-adap-res.xinp
-Equation solver: 2
-Number of Gauss points: 4
 LR-spline basis functions are used
 Number of elements    64
 Number of nodes       81
@@ -31,63 +28,64 @@ Error estimates based on >>> Pure residuals <<<
 Error estimate             |T^h|_res : 0.125968
 Relative error (%) : 91.1701
 Effectivity index  : 6.03921
-Root mean square (RMS) of error      : 0.997473
-Min element error                    : 3.07588e-05
-Max element error                    : 0.0488364
-Average element error                : 0.0111482
-Refining 49 basis functions with errors in range \[0.0175035,0.160098\] 10% of max error (0.0160098)
-Refined mesh: 211 elements 234 nodes.
+Root mean square (RMS) of error      : 1.78483
+Min element error                    : 9.46105e-10
+Max element error                    : 0.00238499
+Average element error                : 0.000247937
+Refining 26 basis functions with errors in range \[0.000680429,0.0065528\] 10% of max error (0.00065528)
+Refined mesh: 148 elements 165 nodes.
 Adaptive step 2
-Number of elements    211
-Number of nodes       234
-Number of dofs        234
-Number of constraints 54
-Number of unknowns    180
-L2-norm            : 0.0704152
+Number of elements    148
+Number of nodes       165
+Number of dofs        165
+Number of constraints 45
+Number of unknowns    120
+L2-norm            : 0.0837822
 Max temperature    : 0.333333
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.056442
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.24732
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0564416
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.247316
   L2 norm |T|   = (T,T)^0.5           : 0.0563436
   H1 norm |T|   = a(T,T)^0.5          : 0.247314
-  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 0.000139722
-  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.0104134
-  Exact relative error (%)            : 4.21059
+  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 0.000208672
+  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.011398
+  Exact relative error (%)            : 4.60873
 Error estimates based on >>> Pure residuals <<<
-  Residual norm                      : 0.0631065
-  Effectivity index eta^res          : 6.06015
-Error estimate             |T^h|_res : 0.0631065
-Relative error (%) : 74.5369
-Effectivity index  : 6.06015
-Root mean square (RMS) of error      : 0.818224
-Min element error                    : 3.07588e-05
-Max element error                    : 0.0134167
-Average element error                : 0.00336233
-Refining 181 basis functions with errors in range \[0.00487477,0.0487098\] 10% of max error (0.00487098)
-Refined mesh: 754 elements 788 nodes.
+  Residual norm                      : 0.0674546
+  Effectivity index eta^res          : 5.91811
+Error estimate             |T^h|_res : 0.0674546
+Relative error (%) : 76.6937
+Effectivity index  : 5.91811
+Root mean square (RMS) of error      : 1.11494
+Min element error                    : 9.46105e-10
+Max element error                    : 0.000180008
+Average element error                : 3.07441e-05
+Refining 98 basis functions with errors in range \[6.0148e-05,0.000596129\] 10% of max error (5.96129e-05)
+Refined mesh: 448 elements 471 nodes.
 Adaptive step 3
-Number of elements    754
-Number of nodes       788
-Number of dofs        788
-Number of constraints 96
-Number of unknowns    692
-L2-norm            : 0.0703668
+Number of elements    448
+Number of nodes       471
+Number of dofs        471
+Number of constraints 77
+Number of unknowns    394
+L2-norm            : 0.0906022
 Max temperature    : 0.333333
 >>> Norm summary for AdvectionDiffusion <<<
-  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563674
-  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.247307
+  L2 norm |T^h| = (T^h,T^h)^0.5       : 0.0563679
+  H1 norm |T^h| = a(T^h,T^h)^0.5      : 0.24731
   L2 norm |T|   = (T,T)^0.5           : 0.0563436
   H1 norm |T|   = a(T,T)^0.5          : 0.247314
-  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 3.60383e-05
-  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00523276
-  Exact relative error (%)            : 2.11584
+  L2 norm |e|   = (e,e)^0,5, e=T-T^h  : 6.56649e-05
+  H1 norm |e|   = a(e,e)^0.5, e=T-T^h : 0.00622444
+  Exact relative error (%)            : 2.51682
 Error estimates based on >>> Pure residuals <<<
-  Residual norm                      : 0.0317011
-  Effectivity index eta^res          : 6.0582
-Error estimate             |T^h|_res : 0.0317011
-Relative error (%) : 49.0196
-Effectivity index  : 6.0582
-Root mean square (RMS) of error      : 0.715177
-Min element error                    : 3.07588e-05
-Max element error                    : 0.00351516
-Average element error                : 0.000939048
+  Residual norm                      : 0.0366483
+  Effectivity index eta^res          : 5.88781
+Error estimate             |T^h|_res : 0.0366483
+Relative error (%) : 54.5084
+Effectivity index  : 5.88781
+Root mean square (RMS) of error      : 0.882191
+Min element error                    : 9.46105e-10
+Max element error                    : 1.50024e-05
+Average element error                : 2.99799e-06
+   \* Stopping the adaptive cycles as max steps 3 was reached.


### PR DESCRIPTION
this to be correct with multi-patch models where we sum multiple
contributions to boundary functions. also this is needed in the
boussinesq application where we already have squared the
navier-stokes errors