### PR TITLE
changed: use Vec3 overload for ResidualOps::Laplacian

### DIFF
--- a/Common/AdvectionDiffusion/AdvectionDiffusionBDF.C
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionBDF.C
@@ -141,7 +141,7 @@ bool AdvectionDiffusionBDF::evalInt (LocalIntegral& elmInt,
   WeakOps::Mass(elMat.A[0], fe, s + reac);
 
   if (timeMethod == TimeIntegration::THETA) {
-    Matrix grad(1,nsd);
+    Vec3 grad;
     Vector g;
     fe.dNdX.multiply(elMat.vec[1], g, true);
     grad = g;


### PR DESCRIPTION
So we can remove templating in upstream