### PR TITLE
Changed: Remove unnecessary override of setMode() methods

### DIFF
--- a/Common/AdvectionDiffusion/AdvectionDiffusionBDF.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionBDF.h
@@ -16,20 +16,6 @@
 
 #include "AdvectionDiffusion.h"
 #include "BDF.h"
-#include "Integrand.h"
-#include "MatVec.h"
-#include "SIMenums.h"
-#include "TimeIntUtils.h"
-
-#include <vector>
-
-
-class AnaSol;
-class FiniteElement;
-class LocalIntegral;
-class NormBase;
-class Vec3;
-struct TimeDomain;
 
 
 /*!
@@ -89,10 +75,6 @@ public:
   //! returned pointer value.
   //! \param[in] asol Pointer to analytical solution (optional)
   NormBase* getNormIntegrand(AnaSol* asol = 0) const override;
-
-  //! \brief Defines the solution mode before the element assembly is started.
-  //! \param[in] mode The solution mode to use
-  void setMode(SIM::SolutionMode mode) override;
 
   //! \brief Returns time integration method used.
   TimeIntegration::Method getTimeMethod() const override { return timeMethod; }

--- a/Common/AdvectionDiffusion/AdvectionDiffusionExplicit.C
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionExplicit.C
@@ -13,21 +13,6 @@
 //==============================================================================
 
 #include "AdvectionDiffusionExplicit.h"
-#include "ADFluidProperties.h"
-
-#include "ElmMats.h"
-#include "Function.h"
-#include "MatVec.h"
-#include "Vec3.h"
-
-#include <ext/alloc_traits.h>
-#include <memory>
-#include <vector>
-
-
-class FiniteElement;
-class LocalIntegral;
-class NormBase;
 
 
 AdvectionDiffusionExplicit::AdvectionDiffusionExplicit (unsigned short int n,
@@ -87,14 +72,4 @@ NormBase* AdvectionDiffusionExplicit::getNormIntegrand (AnaSol* asol) const
     return new AdvectionDiffusionNorm(*const_cast<AdvectionDiffusionExplicit*>(this),asol);
   else
     return new AdvectionDiffusionNorm(*const_cast<AdvectionDiffusionExplicit*>(this));
-}
-
-
-void AdvectionDiffusionExplicit::setMode (SIM::SolutionMode mode)
-{
-  m_mode = mode;
-  if (mode == SIM::STATIC)
-    primsol.clear();
-  else
-    primsol.resize(1 + TimeIntegration::Steps(timeMethod));
 }

--- a/Common/AdvectionDiffusion/AdvectionDiffusionExplicit.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionExplicit.h
@@ -16,19 +16,6 @@
 
 #include "AdvectionDiffusion.h"
 
-#include "Integrand.h"
-#include "SIMenums.h"
-#include "TimeIntUtils.h"
-
-#include <cstddef>
-
-
-class AnaSol;
-class FiniteElement;
-class LocalIntegral;
-class NormBase;
-class Vec3;
-
 
 /*!
   \brief Class representing the integrand of a time-dependent
@@ -82,10 +69,6 @@ public:
   //! returned pointer value.
   //! \param[in] asol Pointer to analytical solution (optional)
   NormBase* getNormIntegrand(AnaSol* asol = 0) const override;
-
-  //! \brief Defines the solution mode before the element assembly is started.
-  //! \param[in] mode The solution mode to use
-  void setMode(SIM::SolutionMode mode) override;
 
 protected:
   TimeIntegration::Method timeMethod; //!< Time stepping method used

--- a/Common/AdvectionDiffusion/AdvectionDiffusionImplicit.C
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionImplicit.C
@@ -13,30 +13,15 @@
 //==============================================================================
 
 #include "AdvectionDiffusionImplicit.h"
-#include "ADFluidProperties.h"
 
-#include "ElmMats.h"
 #include "FiniteElement.h"
-#include "Function.h"
-#include "MatVec.h"
-#include "matrix.h"
-#include "Vec3.h"
 #include "Vec3Oper.h"
-
-#include <cstddef>
-#include <memory>
-#include <vector>
-
-
-class AnaSol;
-class LocalIntegral;
-class NormBase;
 
 
 AdvectionDiffusionImplicit::AdvectionDiffusionImplicit (unsigned short int n,
                                                         TimeIntegration::Method method,
                                                         int itg_type, int form) :
-  AdvectionDiffusion(n, itg_type == Integrand::STANDARD?NONE:SUPG),
+  AdvectionDiffusion(n, itg_type == Integrand::STANDARD ? NONE :SUPG),
   timeMethod(method)
 {
   primsol.resize(2);
@@ -93,14 +78,4 @@ NormBase* AdvectionDiffusionImplicit::getNormIntegrand (AnaSol* asol) const
     return new AdvectionDiffusionNorm(*const_cast<AdvectionDiffusionImplicit*>(this),asol);
   else
     return new AdvectionDiffusionNorm(*const_cast<AdvectionDiffusionImplicit*>(this));
-}
-
-
-void AdvectionDiffusionImplicit::setMode (SIM::SolutionMode mode)
-{
-  m_mode = mode;
-  if (mode == SIM::STATIC)
-    primsol.clear();
-  else
-    primsol.resize(2);
 }

--- a/Common/AdvectionDiffusion/AdvectionDiffusionImplicit.h
+++ b/Common/AdvectionDiffusion/AdvectionDiffusionImplicit.h
@@ -17,18 +17,6 @@
 
 #include "AdvectionDiffusion.h"
 
-#include "Integrand.h"
-#include "SIMenums.h"
-#include "TimeIntUtils.h"
-
-
-class AnaSol;
-class FiniteElement;
-class LocalIntegral;
-class NormBase;
-struct TimeDomain;
-class Vec3;
-
 
 /*!
   \brief Class representing the integrand of Advection-Diffusion problem
@@ -44,8 +32,8 @@ public:
   //! \param[in] itg_type The integrand type to use
   //! \param[in] form Integrand formulation
   explicit AdvectionDiffusionImplicit(unsigned short int n,
-                             TimeIntegration::Method method,
-                             int itg_type = STANDARD, int form = 0);
+                                      TimeIntegration::Method method,
+                                      int itg_type = STANDARD, int form = 0);
 
   using AdvectionDiffusion::evalInt;
   //! \brief Evaluates the integrand at an interior point.
@@ -64,10 +52,6 @@ public:
   //! returned pointer value.
   //! \param[in] asol Pointer to analytical solution (optional)
   NormBase* getNormIntegrand(AnaSol* asol = 0) const override;
-
-  //! \brief Defines the solution mode before the element assembly is started.
-  //! \param[in] mode The solution mode to use
-  void setMode(SIM::SolutionMode mode) override;
 
 protected:
   TimeIntegration::Method timeMethod; //!< Time stepping method used


### PR DESCRIPTION
The parent class `setMode()` method is sufficient for these classes, as it will not touch the `primsol` member after it is allocated by the constructors, and there is no switch between DYNAMIC and STATIC mode during the simulation - it stays DYNAMIC throughout. Only the stationary solver uses the STATIC mode.

Also remove lots of superfluous include statements and forward declarations.