### PR TITLE
Fixed: Usage of the SIMadmin::msgLevel flag to control log print

### DIFF
--- a/Common/AdvectionDiffusion/SIMAD.C
+++ b/Common/AdvectionDiffusion/SIMAD.C
@@ -55,8 +55,11 @@ SIMAD<Dim,Integrand>::SIMAD (Integrand& ad, bool alone) :
   inputContext("advectiondiffusion")
 {
   standalone = alone;
+  stationary = AD.getTimeMethod() == TimeIntegration::NONE;
   Dim::myProblem = &AD;
   Dim::myHeading = "Advection-Diffusion solver";
+  if (!stationary)
+    Dim::msgLevel = 1; // prints primary solution summary only
 }
 
 
@@ -215,15 +218,14 @@ bool SIMAD<Dim,Integrand>::init (const TimeStep&)
 
   if (useAnasolSource) {
     using ADSource = AD::AdvectionDiffusionAnaSolSource;
-    if (Dim::mySol && (AD.getAdvectionField() || anaVel)) {
-      const VecFunc& u = AD.getAdvectionField() ?
-                             *AD.getAdvectionField() : *anaVel;
-      AD.setSource(new ADSource(*Dim::mySol,
-                                u,
+    if (Dim::mySol && AD.getAdvectionField())
+      anaVel = AD.getAdvectionField();
+    if (Dim::mySol && anaVel)
+      AD.setSource(new ADSource(*Dim::mySol, *anaVel,
                                 AD.getFluidProperties(),
                                 AD.getReactionField(),
-                                AD.getTimeMethod() == TimeIntegration::NONE));
-    } else
+                                stationary));
+    else
       std::cerr << "*** Asked to use source function from analytic solution, but no"
                     " analytic solution given. No source function added." << std::endl;
   }
@@ -294,7 +296,6 @@ bool SIMAD<Dim,Integrand>::advanceStep (TimeStep&)
   this->pushSolution(); // Update solution vectors between time steps
   AD.advanceStep();
   return true;
-
 }
 
 
@@ -307,30 +308,26 @@ bool SIMAD<Dim,Integrand>::solveStep (const TimeStep& tp, bool)
   if (Dim::msgLevel >= 0 && standalone && tp.multiSteps())
     IFEM::cout <<"\n  step = "<< tp.step <<"  time = "<< tp.time.t << std::endl;
 
-  Vector dummy;
-  this->updateDirichlet(tp.time.t,&dummy);
-
-  int msgL = Dim::msgLevel-1;
-  if (!standalone)
-    std::swap(msgL, Dim::msgLevel);
+  if (!this->initDirichlet(tp.time.t))
+    return false;
 
   if (!this->assembleSystem(tp.time,solution))
     return false;
 
-  if (!this->solveSystem(solution.front(),Dim::msgLevel-1,"temperature "))
+  const int printSol = tp.multiSteps() && Dim::msgLevel > 0 ? 0 : Dim::msgLevel;
+  if (!this->solveSystem(solution.front(),printSol,"temperature"))
     return false;
+  else if (printSol == 0)
+    this->printSolutionSummary(solution.front(),0,"temperature");
 
   if (!standalone)
-    std::swap(msgL, Dim::msgLevel);
-
-  if (Dim::msgLevel < 2 || !standalone)
   {
     size_t iMax[1];
     double dMax[1];
     double normL2 = this->solutionNorms(solution.front(),dMax,iMax,1);
     IFEM::cout <<"\n  Temperature summary:  L2-norm        : "<< normL2
-              <<"\n                       Max temperature : "<< dMax[0]
-             << std::endl;
+               <<"\n                       Max temperature : "<< dMax[0]
+               << std::endl;
   }
 
   return true;
@@ -360,18 +357,15 @@ bool SIMAD<Dim,Integrand>::saveStep (const TimeStep& tp, int& nBlock)
   if (tp.step%Dim::opt.saveInc > 0 || Dim::opt.format < 0)
     return true;
 
-  const TimeIntegration::Method method = AD.getTimeMethod();
-  int iDump = method == TimeIntegration::NONE ? 1 :
-              tp.step / Dim::opt.saveInc + 1;
+  int iDump = stationary ? 1 : tp.step / Dim::opt.saveInc + 1;
   if (!this->writeGlvS(this->getSolution(0),iDump,nBlock,
                        tp.time.t,"temperature",70))
     return false;
   else if (!standalone)
     return true;
 
-  double param2 = method == TimeIntegration::NONE ? iDump : tp.time.t;
-  return this->writeGlvStep(iDump, param2,
-                            method == TimeIntegration::NONE ? 1 : 0);
+  double param2 = stationary ? iDump : tp.time.t;
+  return this->writeGlvStep(iDump, param2, stationary ? 1 : 0);
 }
 
 

--- a/Common/AdvectionDiffusion/SIMAD.h
+++ b/Common/AdvectionDiffusion/SIMAD.h
@@ -163,8 +163,7 @@ public:
   void printSolutionSummary(const Vector& solution, int printSol, const char*,
                             std::streamsize outPrec = 0) override
   {
-    this->SIMMultiPatchModelGen<Dim>::printSolutionSummary(solution, printSol,
-                                                           "temperature ", outPrec);
+    this->Dim::printSolutionSummary(solution, printSol, "temperature", outPrec);
   }
 
   //! \brief Set time scaling factor from ODE solver.
@@ -212,6 +211,7 @@ private:
 
   const Vector* extsol = nullptr; //!< Solution vector for adaptive simulators
   bool standalone = false; //!< If \e true, this simulator owns the VTF object
+  bool stationary = false; //!< If \e true, this is a stationary simulator
   std::string inputContext; //!< Input context
   int aCode[2] = {0}; //!< Analytical BC code (used by destructor)
   bool useAnasolSource = false; //!< True to use source function derived from anasol

--- a/Test/Square-abd2-ad-am1.reg
+++ b/Test/Square-abd2-ad-am1.reg
@@ -5,34 +5,34 @@ Number of elements    16
 Number of nodes       64
 Number of dofs        64
 Number of unknowns    36
-  step = 1  time = 0.1
+step=1  time=0.1
 L2-norm            : 3.23481e-05
 Max temperature    : 0.000114014
-  step=2  time=0.2
+step=2  time=0.2
 L2-norm            : 0.000195032
 Max temperature    : 0.000701216
-  step = 3  time = 0.3
+step=3  time=0.3
 L2-norm            : 0.000601822
 Max temperature    : 0.00217921
-  step = 4  time = 0.4
+step=4  time=0.4
 L2-norm            : 0.00137102
 Max temperature    : 0.00498102
-  step = 5  time = 0.5
+step=5  time=0.5
 L2-norm            : 0.00262234
 Max temperature    : 0.00954442
-  step = 6  time = 0.6
+step=6  time=0.6
 L2-norm            : 0.00447601
 Max temperature    : 0.0163087
-  step = 7  time = 0.7
+step=7  time=0.7
 L2-norm            : 0.00705237
 Max temperature    : 0.0257138
-  step = 8  time = 0.8
+step=8  time=0.8
 L2-norm            : 0.0104719
 Max temperature    : 0.0381997
-  step = 9  time = 0.9
+step=9  time=0.9
 L2-norm            : 0.0148549
 Max temperature    : 0.0542063
-  step = 10  time = 1
+step=10  time=1
 L2-norm            : 0.0203219
 Max temperature    : 0.074174
   Time integration completed.

--- a/Test/Square-abd2-ad-am2.reg
+++ b/Test/Square-abd2-ad-am2.reg
@@ -5,34 +5,34 @@ Number of elements    16
 Number of nodes       64
 Number of dofs        64
 Number of unknowns    36
-  step = 1  time = 0.1
+step=1  time=0.1
 L2-norm            : 3.23481e-05
 Max temperature    : 0.000114014
-  step = 2  time = 0.2
+step=2  time=0.2
 L2-norm            : 0.000164903
 Max temperature    : 0.000600086
-  step = 3  time = 0.3
+step=3  time=0.3
 L2-norm            : 0.000546667
 Max temperature    : 0.00199659
-  step = 4  time = 0.4
+step=4  time=0.4
 L2-norm            : 0.00128912
 Max temperature    : 0.00470861
-  step = 5  time = 0.5
+step=5  time=0.5
 L2-norm            : 0.0025138
 Max temperature    : 0.00918426
-  step = 6  time = 0.6
+step=6  time=0.6
 L2-norm            : 0.00434039
 Max temperature    : 0.0158584
-  step = 7  time = 0.7
+step=7  time=0.7
 L2-norm            : 0.00688985
 Max temperature    : 0.0251744
-  step = 8  time = 0.8
+step=8  time=0.8
 L2-norm            : 0.0102823
 Max temperature    : 0.0375704
-  step = 9  time = 0.9
+step=9  time=0.9
 L2-norm            : 0.0146383
 Max temperature    : 0.0534877
-  step = 10  time = 1
+step=10  time=1
 L2-norm            : 0.0200783
 Max temperature    : 0.0733656
   Time integration completed.

--- a/Test/Square-abd2-ad-am3.reg
+++ b/Test/Square-abd2-ad-am3.reg
@@ -5,34 +5,34 @@ Number of elements    16
 Number of nodes       64
 Number of dofs        64
 Number of unknowns    36
-  step = 1  time = 0.1
+step=1  time=0.1
 L2-norm            : 3.23481e-05
 Max temperature    : 0.000114014
-  step = 2  time = 0.2
+step=2  time=0.2
 L2-norm            : 0.000164903
 Max temperature    : 0.000600086
-  step = 3  time = 0.3
+step=3  time=0.3
 L2-norm            : 0.000542476
 Max temperature    : 0.00198279
-  step = 4  time = 0.4
+step=4  time=0.4
 L2-norm            : 0.00128483
 Max temperature    : 0.00469391
-  step = 5  time = 0.5
+step=5  time=0.5
 L2-norm            : 0.00250948
 Max temperature    : 0.00917069
-  step = 6  time = 0.6
+step=6  time=0.6
 L2-norm            : 0.00433561
 Max temperature    : 0.0158416
-  step = 7  time = 0.7
+step=7  time=0.7
 L2-norm            : 0.00688574
 Max temperature    : 0.0251619
-  step = 8  time = 0.8
+step=8  time=0.8
 L2-norm            : 0.0102772
 Max temperature    : 0.0375525
-  step = 9  time = 0.9
+step=9  time=0.9
 L2-norm            : 0.0146345
 Max temperature    : 0.053476
-  step = 10  time = 1
+step=10  time=1
 L2-norm            : 0.020073
 Max temperature    : 0.0733472
   Time integration completed.

--- a/Test/Square-abd2-ad-am4.reg
+++ b/Test/Square-abd2-ad-am4.reg
@@ -5,34 +5,34 @@ Number of elements    16
 Number of nodes       64
 Number of dofs        64
 Number of unknowns    36
-  step = 1  time = 0.1
+step=1  time=0.1
 L2-norm            : 3.23481e-05
 Max temperature    : 0.000114014
-  step = 2  time = 0.2
+step=2  time=0.2
 L2-norm            : 0.000164903
 Max temperature    : 0.000600086
-  step = 3  time = 0.3
+step=3  time=0.3
 L2-norm            : 0.000542476
 Max temperature    : 0.00198279
-  step = 4  time = 0.4
+step=4  time=0.4
 L2-norm            : 0.00128474
 Max temperature    : 0.00469305
-  step = 5  time = 0.5
+step=5  time=0.5
 L2-norm            : 0.00250962
 Max temperature    : 0.00917243
-  step = 6  time = 0.6
+step=6  time=0.6
 L2-norm            : 0.00433495
 Max temperature    : 0.0158368
-  step = 7  time = 0.7
+step=7  time=0.7
 L2-norm            : 0.00688718
 Max temperature    : 0.0251713
-  step = 8  time = 0.8
+step=8  time=0.8
 L2-norm            : 0.0102744
 Max temperature    : 0.0375354
-  step = 9  time = 0.9
+step=9  time=0.9
 L2-norm            : 0.0146398
 Max temperature    : 0.0535052
-  step = 10  time = 1
+step=10  time=1
 L2-norm            : 0.0200634
 Max temperature    : 0.0733
   Time integration completed.


### PR DESCRIPTION
Added: bool member stationary in SIMAD, for the convenience.

Downstream of OPM/IFEM#854